### PR TITLE
Add dependency declarations and tests

### DIFF
--- a/aftermath.py
+++ b/aftermath.py
@@ -18,7 +18,7 @@ f.close()
 f = open("".join([raw_fn,"_",py,".xml"]), "w")
 txt = txt.replace("UTest", "".join(["UTest_",py,"_"]))
 f.write(txt)
-f.close
+f.close()
 
 os.remove(filename)
 

--- a/nucosObs/observable.py
+++ b/nucosObs/observable.py
@@ -22,7 +22,9 @@ class Observable():
 
     def register(self, observer, concurrent=[]):
         if not concurrent:
-            self.q.update({observer.name: aio.Queue(loop=self.loop)})
+            # In modern Python versions the loop parameter is deprecated
+            # and removed. Create queue bound to the current loop.
+            self.q.update({observer.name: aio.Queue()})
             observer._queue = self.q[observer.name]
         else:
             concurrentQueues = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp
+websockets

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,5 @@ setup(name=name,
       package_dir=package_dir,
       package_data=package_data,
       scripts=scripts,
-      install_requires=['websockets']
+      install_requires=['websockets', 'aiohttp']
       )

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,52 @@
+import asyncio as aio
+
+import nucosObs
+from nucosObs.observable import Observable
+from nucosObs.observer import Observer, broadcast
+
+
+class DummyObserver(Observer):
+    def __init__(self, name, obs):
+        super().__init__(name, obs)
+        self.called = False
+
+    async def greet(self, msg):
+        self.called = msg
+        await broadcast.put({"name": "broadcast", "args": [{"action": "stop_observer"}]})
+
+
+import unittest
+
+
+class ObserverTests(unittest.TestCase):
+
+    def setUp(self):
+        nucosObs.allObs.clear()
+        nucosObs.allObservables.clear()
+
+    def tearDown(self):
+        if not nucosObs.loop.is_closed():
+            nucosObs.loop.close()
+
+    def test_event_delivery(self):
+        loop = aio.new_event_loop()
+        aio.set_event_loop(loop)
+        nucosObs.loop = loop
+
+        obs = Observable()
+        ob = DummyObserver("O", obs)
+        aio.ensure_future(obs.put({"name": "greet", "args": ["hello"]}))
+        aio.ensure_future(obs.put({"action": "stop_observer"}))
+        nucosObs.main_loop([], test=True)
+        self.assertEqual(ob.called, "hello")
+        loop.close()
+
+    def test_register_queue(self):
+        obs = Observable()
+        ob = DummyObserver("O", obs)
+        self.assertIn(ob.name, obs.q)
+        self.assertIs(ob._queue, obs.q[ob.name])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- specify `aiohttp` runtime dependency in setup
- add `requirements.txt`
- fix missing file close in `aftermath.py`
- make queue creation compatible with new Python versions
- add basic observer tests

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_684965a59090832695fa7349e137868a