### PR TITLE
Fix asyncio compatibility issues

### DIFF
--- a/nucosObs/__init__.py
+++ b/nucosObs/__init__.py
@@ -7,7 +7,10 @@ pool = ThreadPoolExecutor(4)
 allObs = []
 allObservables = []
 
-loop = aio.get_event_loop()
+# Create a default event loop on import so that modules relying on the loop
+# do not trigger a deprecation warning with ``get_event_loop``.
+loop = aio.new_event_loop()
+aio.set_event_loop(loop)
 debug = [False]
 
 

--- a/nucosObs/stdinInterface.py
+++ b/nucosObs/stdinInterface.py
@@ -12,14 +12,24 @@ class StdinInterface(object):
     def __init__(self, observable):
         """Create the interface and attach ``observable`` for output."""
         self.loop = loop
-        self.q = aio.Queue(loop=self.loop)
-        self.loop.add_reader(sys.stdin, self.got_input)
+        # `asyncio.Queue` does not take a loop parameter since Python 3.8
+        # and specifying it raises an exception on modern versions.
+        self.q = aio.Queue()
+        try:
+            # In test environments ``stdin`` might not be a real file
+            # object which would raise ``ValueError`` when registering a
+            # reader. Ignore such failures so the interface can still be
+            # constructed.
+            self.loop.add_reader(sys.stdin, self.got_input)
+        except (ValueError, NotImplementedError):
+            pass
         self.observable = observable
         self.stop = False
 
     def got_input(self):
         """Callback for the event loop when input is available."""
-        aio.ensure_future(self.q.put(sys.stdin.readline()), loop=self.loop)
+        # Schedule putting the input into the queue on the running loop
+        self.loop.create_task(self.q.put(sys.stdin.readline()))
 
     async def get_ui(self):
         """Coroutine processing the input queue and dispatching commands."""

--- a/nucosObs/twoWayInterface.py
+++ b/nucosObs/twoWayInterface.py
@@ -12,7 +12,8 @@ class TwoWayInterface(object):
     def __init__(self, observables_dict, send_all=False):
         """Create interface with mapping of names to observables."""
         self.loop = loop
-        self.q = aio.Queue(loop=self.loop)
+        # Remove deprecated loop parameter when creating the queue
+        self.q = aio.Queue()
         self.observables_dict = observables_dict
         self.stop = False
         self.send_all = send_all


### PR DESCRIPTION
## Summary
- update default event loop creation to avoid deprecation warnings
- modernize StdinInterface and TwoWayInterface queue creation
- handle stdin registration failures gracefully

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684983fb66ec8326ad3fcd36f03d9ec5